### PR TITLE
feat: Limit news articles to last 2 days only

### DIFF
--- a/src/fetchNews.js
+++ b/src/fetchNews.js
@@ -60,12 +60,21 @@ export async function fetchNewsFromSources() {
     }
   });
 
+  // Filter articles to only include those from the last 2 days
+  const twoDaysAgo = new Date();
+  twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+  
+  const recentArticles = allNews.filter(article => {
+    const articleDate = new Date(article.publishedAt);
+    return articleDate >= twoDaysAgo;
+  });
+
   // Sort by date (most recent first)
-  allNews.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+  recentArticles.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
   
   // Limit to top 60 business stories
   return {
-    articles: allNews.slice(0, 60),
+    articles: recentArticles.slice(0, 60),
     fetchedAt: new Date().toISOString(),
     errors
   };

--- a/src/fetchPortfolioNews.js
+++ b/src/fetchPortfolioNews.js
@@ -91,12 +91,21 @@ export async function fetchPortfolioNews() {
     new Map(allNews.map(item => [item.title, item])).values()
   );
   
+  // Filter articles to only include those from the last 2 days
+  const twoDaysAgo = new Date();
+  twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+  
+  const recentUniqueNews = uniqueNews.filter(article => {
+    const articleDate = new Date(article.publishedAt);
+    return articleDate >= twoDaysAgo;
+  });
+  
   // Sort by date (most recent first)
-  uniqueNews.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
+  recentUniqueNews.sort((a, b) => new Date(b.publishedAt) - new Date(a.publishedAt));
   
   // Limit to top 100 relevant stories
   return {
-    articles: uniqueNews.slice(0, 100),
+    articles: recentUniqueNews.slice(0, 100),
     fetchedAt: new Date().toISOString(),
     portfolioStocks: portfolio.length,
     errors


### PR DESCRIPTION
## Summary
- Added date filtering to only include news articles from the last 2 days
- Applied to both daily market briefing and portfolio news reports
- Reduces noise and ensures only the most recent, relevant news is included

## Test Results
Both newsletters tested successfully in TEST_RUN mode:
- Daily Market Briefing: 36 articles fetched
- Portfolio News: 82 portfolio-related articles fetched

🤖 Generated with [Claude Code](https://claude.ai/code)